### PR TITLE
chore: fix repository metadata URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git"
+    "url": "https://github.com/bluecatengineering/l10n-packages.git"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",

--- a/packages/ast2icu/package.json
+++ b/packages/ast2icu/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git",
+    "url": "https://github.com/bluecatengineering/l10n-packages.git",
     "directory": "packages/ast2icu"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
   "bin": "./cli.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git",
+    "url": "https://github.com/bluecatengineering/l10n-packages.git",
     "directory": "packages/cli"
   },
   "dependencies": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git",
+    "url": "https://github.com/bluecatengineering/l10n-packages.git",
     "directory": "packages/config"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git",
+    "url": "https://github.com/bluecatengineering/l10n-packages.git",
     "directory": "packages/core"
   },
   "devDependencies": {

--- a/packages/icu2obj/package.json
+++ b/packages/icu2obj/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git",
+    "url": "https://github.com/bluecatengineering/l10n-packages.git",
     "directory": "packages/icu2obj"
   },
   "dependencies": {

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git",
+    "url": "https://github.com/bluecatengineering/l10n-packages.git",
     "directory": "packages/jest"
   },
   "dependencies": {

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git",
+    "url": "https://github.com/bluecatengineering/l10n-packages.git",
     "directory": "packages/loader"
   },
   "dependencies": {

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git",
+    "url": "https://github.com/bluecatengineering/l10n-packages.git",
     "directory": "packages/macro"
   },
   "peerDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git@github.com:bluecatengineering/l10n-packages.git",
+    "url": "https://github.com/bluecatengineering/l10n-packages.git",
     "directory": "packages/types"
   }
 }


### PR DESCRIPTION
## Summary

- update repository URLs from the SSH shorthand to the public HTTPS GitHub URL
- keep the existing package directory metadata intact for each workspace package

## Validation

- checked all package manifests parse and point to `https://github.com/bluecatengineering/l10n-packages.git`
- `npm pack --dry-run --ignore-scripts --workspaces --json`
- `git diff --check`
